### PR TITLE
docs: Add FAQ for Translators

### DIFF
--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -6,6 +6,7 @@ This document provides information regarding translations for bitcoin.org.
 * [Handling Translations on GitHub](#handling-translations-on-github)
 * [Getting Started with the Translation Team](#getting-started-with-the-translation-team)
 * [Responsibilities and Tasks for each User Role](#responsibilities-and-tasks-for-each-user-role)
+* [Frequently Asked Questions](#frequently-asked-questions)
 
 ---
 
@@ -154,3 +155,146 @@ Various people across all language teams are coordinators. For a number of langu
 ### 4. Translators
 * Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
 * Extending the glossary with translations for necessary and general terms.
+    
+___
+
+## Frequently Asked Questions
+
+This FAQ intends to provide answers to some questions that might occur while translating bitcoin.org on Transifex. If you feel that some questions are missing, get in contact with one of the team leaders or the website Maintainer. Team Leaders are Simon AKA “Komodorpudel” (Telegram: @Komodorpudel) and Hendrawan AKA “khendraw” (Telegram: @khendraw). The website maintainer is Will Binns ([will@bitcoin.org](mailto:will@bitcoin.org)). We are happy to add your question to the FAQ. 
+
+### What’s Transifex? 
+
+Transifex is a cloud-based localization platform, translation management software. It is used to manage the work on the various translations of bitcoin.org. 
+     
+### I know how to speak certain language and want to help – how can I get started? 
+
+Just jump to the [Getting Started with the Translation Team](#getting-started-with-the-translation-team) section in this document. Everything is described there. 
+
+### Do I need to know how to use GitHub to translate? 
+
+No, even though the website is managed on GitHub, it is only necessary to understand how to translate bitcoin.org on Transifex. Everything GitHub-related, such as creating a Pull Request to update a specific translation of bitcoin.org, is handled by Will Binns, the website maintainer. However, if you are familiar with GitHub, you are welcome to create your own Pull Request to update specific translations of bitcoin.org. Just take a look at section “Handling Translations on GitHub” in this document. 
+
+### How do I use Transifex? 
+
+It is probably best if you take a look at the info provided by [Transifex](https://docs.transifex.com/getting-started-1/translators). Everything beyond the basics is probably best learned by clicking through the menus of Transifex. 
+
+### What are resources? 
+
+A resource consists of a number of strings, with a string being for example a paragraph or headline. The first resource "bitcoin.org" contains all strings of the main page. If you are no Bitcoin expert, start here. Everything else that follows starts with "devdocs...", indicating that these files are part of the developer documentation. It is recommended that you only try to translate the developer documentation if you are an experienced Bitcoin user and/or developer with a profound understanding. 
+
+### How and when are my translations put to use? 
+
+Your translations are welcome and help to improve bitcoin.org, the unofficial but original website of Bitcoin. Bitcoin.org was originally registered and owned by Bitcoin's first two developers, Satoshi Nakamoto and Martti Malmi. Translations are usually only pushed to the website if:
+
+1. the corresponding resource that contains the translations is 100% translated and 100% reviewed and 
+2. a Team Leader (currently Simon AKA “Komodorpudel” (Telegram: @Komodorpudel) or Hendrawan AKA “khendraw” (Telegram: @khendraw) is notified about a resource being finished. 
+
+### A reviewed translation contains a mistake. What should I do? 
+
+This depends on whether you are (a) a translator or (b) a reviewer or higher.
+
+If (a) is true, you won’t be able to change the string yourself. Thus, make a comment about the issue and mention reviewers and/or coordinators within your language team from whom you know that they are active by using @username. If no one responsible in your team is active, link one of the Team Leaders (currently Simon AKA “Komodorpudel” (Telegram: @Komodorpudel) or Hendrawan AKA “khendraw” (Telegram: @khendraw). 
+
+If (b) is true, and you are sure that the translation contains a mistake, just edit the string. If you are not 100% sure, make a comment about the issue and mention reviewers and/or coordinators within your language team from whom you know that they are active by using @username. 
+     
+### Will I be paid for translating for bitcoin.org? 
+
+In general, no, however there are periods like during the summer 2018, in which we were able to compensate many volunteers. Compensating volunteers from time to time for their efforts is something we strive to be able to continue to do. 
+
+### Who is responsible for the translation project on Transifex? 
+
+Bitcoin.org itself is owned by theymos and cobra-bitcoin. The website is maintained by Will Binns with input from many other volunteers on GitHub. Will is also the project maintainer for the translation project on Transifex, with the effective oversight on translations done by Simon AKA “Komodorpudel” (Telegram: @Komodorpudel) and Hendrawan AKA “khendraw” (Telegram: @khendraw). 
+
+### I found a mistake in the original English version. What should I do? 
+
+Comment the mistake and mention one of the Team Leaders by using @username or contact the Team Leaders directly via message. Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: @Komodorpudel) or Hendrawan AKA “khendraw” (Telegram: @khendraw). 
+
+### How do I get in contact with other translators? 
+
+You can join our Telegram Group (https://t.me/joinchat/Bgh47RC1BZb2YE6u8iznOg). The website maintainer, both team leaders for translations, and a bunch of coordinators, reviewers, and translators are present in this group. 
+
+If you only want to contact members of your language team on Transifex, click on "Teams" on the top and then on the small blue chat bubble symbol. By clicking on “New discussion”, you can create language specific discussions. Everyone in the language team will receive an (email) notification about this. 
+
+Apart from that, you can obviously contact other translators by using the direct message function on Transifex. 
+
+### I translated a string completely. What’s next? 
+
+Great work! Now that the string is translated, it has to be reviewed. If there are active reviewers in your team, just wait for them to review to string. Get in contact with them if you feel that this is necessary. If there are no active reviewers (and coordinators) in your team, get in contact with the Team Leaders. Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: @Komodorpudel) or Hendrawan AKA “khendraw” (Telegram: @khendraw). We can promote you to reviewer so that you can review your own strings as a last solution. 
+
+### I am not sure how to translate a string/word. Where can I get help? 
+
+While it is possible to use the comment function on Transifex to ask for help, unfortunately no notification is sent out regarding a comment. Thus, your comment will probably stay unread until someone accidentally finds it. Therefore, we do not recommend using the comment function in this case. 
+
+Instead, please ask your question in the Telegram Group (https://t.me/joinchat/Bgh47RC1BZb2YE6u8iznOg) or contact one of the Team Leaders. Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: @Komodorpudel) or Hendrawan AKA “khendraw” (Telegram: @khendraw). 
+     
+### I can’t find a team for my own language. Who should I contact to add a new language? 
+
+If you do not have a Transifex account yet, just look at point “2. Login and join the Bitcoin.org Translation Team” of the section “Getting Started with the Translation Team” in this document. When your language request is accepted or denied you will receive a notification. 
+
+You can also contact one of the Team Leaders about this. Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: @Komodorpudel) or Hendrawan AKA “khendraw” (Telegram: @khendraw). 
+
+### A suggestion provided by the glossary does not make sense. What should I do? 
+
+Don’t worry. Just ignore it and continue translating. Transifex will display a warning message that a glossary term is missing, but this has no impact on translations being published. 
+
+### I made a mistake in my own translation. What should I do? 
+
+If your translation is not reviewed yet, just correct the mistake and save the new translations. 
+
+If your translation was reviewed and the mistake not corrected in the process, correct the mistake if you are a reviewer yourself or contact the person that reviewed your translation. 
+
+### No one is reviewing the strings I translated. What should I do? 
+
+Contact the reviewers in your language team and ask for a review; either through a direct message on Transifex or through Telegram if you have their Telegram-usernames. 
+
+If the reviewers in your team are not active, contact the coordinator about this. Coordinators are either active native speakers or, if there is currently no active coordinator in place for your language, “Komodorpudel”, one of the Team Leaders, is set as coordinator. 
+
+If you do not receive a reply from an active coordinator, contact Simon AKA “Komodorpudel” (Telegram: @Komodorpudel) or Hendrawan AKA “khendraw” (Telegram: @khendraw). If necessary, we can promote you to reviewer, so you can review your own strings. 
+
+### How to contact a member, reviewer, coordinator or team manager? 
+
+Open the “Dashboard”, click on “Languages” and then on your specific language. Click on “View Members” on the top. 
+
+From there, click on a member’s username to open the member’s profile page. There you can click on “Send Message” on the upper right section of the member profile screen and compose a message. 
+
+### Does a translated string have to have the same number of symbols and/or lines as the original English string? 
+
+In general, no. Translated strings can be as long as they need to be. 
+
+However, if a translated string is significantly longer than the English string, this could cause formatting issues. If this should be the case, we would notify you. 
+
+### I cannot find an answer to my problem in the FAQ. What should I do? 
+
+Join our Telegram Group (https://t.me/joinchat/Bgh47RC1BZb2YE6u8iznOg) and ask your question there. 
+
+Alternatively, you can directly contact the Team Leaders. Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: @Komodorpudel) or Hendrawan AKA “khendraw” (Telegram: @khendraw). We are happy to help. 
+
+### Sometimes “Bitcoin” is written with a capital letter (“Bitcoin”) and other times with a small letter (“bitcoin). Why? 
+
+"Bitcoin" is used when talking about the protocol itself: "You should create a new Bitcoin address for every payment". 
+
+"bitcoin" is used when talking about actual units of bitcoin: "There is no fee to receive bitcoins" 
+
+All together: "You should create a new Bitcoin address every time you want to receive bitcoins" 
+
+Please note that the English version is not entirely consistent on this. If you find an issue, please contact the Team Leaders. Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: @Komodorpudel) or Hendrawan AKA “khendraw” (Telegram: @khendraw). 
+
+### A certain string is hard to translate without any context. Where can I get some? 
+
+In the best case, on Transifex the “string instructions” field between the source text-field and the translation-field contains a link to the location of the string on the website. 
+
+If no link can be found, click on “Context” below the field to enter the translation and use the code to navigate to the corresponding part of bitcoin.org  
+
+Alternatively, you can just google parts of the string in English + "bitcoin.org" attached. Usually this leads to the part of bitcoin.org where the string is located. 
+
+### I finished a string but Transifex displays a warning. What should I do? 
+
+The usual warning message you will see is “Glossary translation for term 'confirmation' missing from translation”. However, this warning message can usually be ignored because in most cases it makes sense to translate certain words not according to the glossary. 
+
+However, if you see an URL-related warning message, this must be corrected because otherwise it will cause issues while publishing the translations. Usually, the problem can easily be solved by checking all the links in the translated text. 
+
+### When and how should I open an Issue? 
+
+You can open Issues by leaving a comment and flagging it as an “Issue”. 
+
+We strongly recommend to not use this function at all. Instead, please contact either the coordinator for your language or one of the Team Leaders directly. Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: @Komodorpudel) or Hendrawan AKA “khendraw” (Telegram: @khendraw).


### PR DESCRIPTION
gh pr checkout 4
This adds a section for frequently asked questions to in the getting
started guide for 'Assisting with Translations' in the GitHub
repository.

Huge thanks goes to @uvhw  for leading the effort to put this
together to help make things easier for new contributors to the
translation project.

This will be merged once tests pass.